### PR TITLE
Use fillPoly to draw wayarea

### DIFF
--- a/map_file/nodes/lanelet2_map_loader/lanelet2_map_loader.cpp
+++ b/map_file/nodes/lanelet2_map_loader/lanelet2_map_loader.cpp
@@ -104,7 +104,7 @@ int main(int argc, char** argv)
   std::string format_version, map_version;
   lanelet::io_handlers::AutowareOsmParser::parseVersions(lanelet2_file_path, &format_version, &map_version);
 
-  ros::Publisher map_bin_pub = nh.advertise<autoware_lanelet2_msgs::MapBin>("/lanelet_map_bin", 1, true);
+  ros::Publisher map_bin_pub = nh.advertise<autoware_lanelet2_msgs::MapBin>("lanelet_map_bin", 1, true);
   autoware_lanelet2_msgs::MapBin map_bin_msg;
   map_bin_msg.header.stamp = ros::Time::now();
   map_bin_msg.header.frame_id = "map";

--- a/map_file/nodes/lanelet2_map_loader/lanelet2_map_visualization.cpp
+++ b/map_file/nodes/lanelet2_map_loader/lanelet2_map_visualization.cpp
@@ -103,7 +103,7 @@ int main(int argc, char** argv)
   ros::NodeHandle rosnode;
   ros::Subscriber bin_map_sub;
 
-  bin_map_sub = rosnode.subscribe("/lanelet_map_bin", 1, binMapCallback);
+  bin_map_sub = rosnode.subscribe("lanelet_map_bin", 1, binMapCallback);
   g_map_pub = rosnode.advertise<visualization_msgs::MarkerArray>("lanelet2_map_viz", 1, true);
 
   ros::spin();

--- a/object_map/include/object_map/object_map_utils.cpp
+++ b/object_map/include/object_map/object_map_utils.cpp
@@ -159,7 +159,8 @@ namespace object_map
         cv_points.emplace_back(cv::Point(cv_x, cv_y));
       }
 
-      cv::fillConvexPoly(filled_image, cv_points.data(), cv_points.size(), cv::Scalar(in_fill_color));
+      std::vector<std::vector<cv::Point>> cv_area_points{cv_points};
+      cv::fillPoly(filled_image, cv_area_points, cv::Scalar(in_fill_color));
     }
 
     // convert to ROS msg


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

laneletからwayareaを生成する際に複雑なポリゴンでは誤った領域をwayareaとしてしまっていたバグの修正
名前空間を絶対pathから相対pathに変更

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix 

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した -->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
